### PR TITLE
removing force ssl

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,7 +3,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security,
   # and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
Hello,

Your app was not deploying correctly because you had "force_ssl" turned on.  This was causing the browser to attempt to connect via HTTPS, which doesnt work.

-Andrew
